### PR TITLE
[skill-tree] Adding query params Routing section

### DIFF
--- a/skill-tree.pum
+++ b/skill-tree.pum
@@ -23,6 +23,7 @@ title Ember Skill Tree (2019)
 *** Routes
 *** Router
 *** Controllers
+*** Query Parameters
 
 ** Components
 *** Ember


### PR DESCRIPTION
I think, it is worth adding `Query Parameters` to `Routing` section in `Ember skill-tree`, too (in addition to `ember-guides skill tree`.